### PR TITLE
Retargeting + changing AddIdentityMongoDbProvider signature

### DIFF
--- a/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
+++ b/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/AspNetCore.Identity.Mongo/MongoIdentityExtensions.cs
+++ b/AspNetCore.Identity.Mongo/MongoIdentityExtensions.cs
@@ -9,37 +9,37 @@ namespace AspNetCore.Identity.Mongo
 {
 	public static class MongoIdentityExtensions
 	{
-	    public static IServiceCollection AddIdentityMongoDbProvider<TUser>(this IServiceCollection services) where TUser : MongoUser
+	    public static IdentityBuilder AddIdentityMongoDbProvider<TUser>(this IServiceCollection services) where TUser : MongoUser
 	    {
 	        return AddIdentityMongoDbProvider<TUser, MongoRole>(services, x => { });
 	    }
 
-        public static IServiceCollection AddIdentityMongoDbProvider<TUser>(this IServiceCollection services,
+        public static IdentityBuilder AddIdentityMongoDbProvider<TUser>(this IServiceCollection services,
 	        Action<MongoIdentityOptions> setupDatabaseAction) where TUser : MongoUser
 	    {
 	        return AddIdentityMongoDbProvider<TUser, MongoRole>(services, setupDatabaseAction);
 	    }
 
-        public static IServiceCollection AddIdentityMongoDbProvider<TUser, TRole>(this IServiceCollection services,
+        public static IdentityBuilder AddIdentityMongoDbProvider<TUser, TRole>(this IServiceCollection services,
 			Action<MongoIdentityOptions> setupDatabaseAction) where TUser : MongoUser
 			where TRole : MongoRole
         {
             return AddIdentityMongoDbProvider<TUser, TRole>(services, x => { }, setupDatabaseAction);
         }
 
-	    public static IServiceCollection AddIdentityMongoDbProvider(this IServiceCollection services,
+	    public static IdentityBuilder AddIdentityMongoDbProvider(this IServiceCollection services,
 	        Action<IdentityOptions> setupIdentityAction, Action<MongoIdentityOptions> setupDatabaseAction)
 	    {
 	        return AddIdentityMongoDbProvider<MongoUser, MongoRole>(services, setupIdentityAction, setupDatabaseAction);
 	    }
 
-	    public static IServiceCollection AddIdentityMongoDbProvider<TUser>(this IServiceCollection services,
+	    public static IdentityBuilder AddIdentityMongoDbProvider<TUser>(this IServiceCollection services,
 	        Action<IdentityOptions> setupIdentityAction, Action<MongoIdentityOptions> setupDatabaseAction) where TUser : MongoUser
 	    {
 	        return AddIdentityMongoDbProvider<TUser, MongoRole>(services, setupIdentityAction, setupDatabaseAction);
         }
 
-	    public static IServiceCollection AddIdentityMongoDbProvider<TUser, TRole>(this IServiceCollection services,
+	    public static IdentityBuilder AddIdentityMongoDbProvider<TUser, TRole>(this IServiceCollection services,
 	        Action<IdentityOptions> setupIdentityAction, Action<MongoIdentityOptions> setupDatabaseAction) where TUser : MongoUser
 	        where TRole : MongoRole
 	    {
@@ -65,7 +65,7 @@ namespace AspNetCore.Identity.Mongo
 	        services.AddTransient<IRoleStore<TRole>>(x => new RoleStore<TRole>(roleCollection));
 	       
 	        
-	        return services;
+	        return builder;
 	    }
 	}
 }


### PR DESCRIPTION
* targeting now netstandard2.0
* returning IdentityBuilder instead of IServiceCollection from AddIdentityMongoDbProvider

Not well tested, but it compiles :)

Addresses #18 and #19 