### PR TITLE
Fix bug when removing users from roles

### DIFF
--- a/AspNetCore.Identity.Mongo/Stores/UserStore.cs
+++ b/AspNetCore.Identity.Mongo/Stores/UserStore.cs
@@ -499,7 +499,7 @@ namespace AspNetCore.Identity.Mongo.Stores
             var role = await _roleStore.FindByNameAsync(roleName, cancellationToken);
             if (role == null) return;
 
-            user.Roles.Remove(roleName);
+            user.Roles.Remove(role.Id);
 
             await Update(user, x => x.Roles, user.Roles);
         }

--- a/SelfCheck/Startup.cs
+++ b/SelfCheck/Startup.cs
@@ -36,7 +36,7 @@ namespace SampleSite
 
             services.AddTransient<IEmailSender, EmailSender>();
 
-            services.AddMvc();
+            services.AddMvc(options => options.EnableEndpointRouting = false);
         }
 
 

--- a/Selfcheck/TestData.cs
+++ b/Selfcheck/TestData.cs
@@ -7,8 +7,9 @@ namespace SampleSite
 {
     public class TestData
     {
-        public static string Username = "USERNAME";
-        public static string Password = "Cicciobello12!";
-        public static string Email = "me@me.com";
+        public const string Username = "USERNAME";
+        public const string Password = "Cicciobello12!";
+        public const string Email = "me@me.com";
+        public const string RoleName = "TestRole";
     }
 }


### PR DESCRIPTION
## Description

Now that roles are added by ID to the user, we also need to remove the roles using the role ID (rather than the role's name).

This was discovered when attempting to remove users from roles in another application. The current workaround is to just update the whole user like so:

``````
ApplicationUser user = await userManager.FindByIdAsync("some-id");
user.Roles.Clear();
await userManager.UpdateAsync(user);
``````

## Changes
- Fix bug by using role ID, instead of role name when removing from users in `UserStore.cs`
- Add test coverage to `SelfCheck.csproj`