### PR TITLE
Adding Claim support for Roles by following the Idenetity pattern

### DIFF
--- a/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj.user
+++ b/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ShowAllFiles>false</ShowAllFiles>
+  </PropertyGroup>
+</Project>

--- a/AspNetCore.Identity.Mongo/Model/MongoRole.cs
+++ b/AspNetCore.Identity.Mongo/Model/MongoRole.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using System.Collections.Generic;
 
 namespace AspNetCore.Identity.Mongo.Model
 {
@@ -14,11 +15,13 @@ namespace AspNetCore.Identity.Mongo.Model
 		{
 			Name = name;
 			NormalizedName = name.ToUpperInvariant();
+			Claims = new List<IdentityRoleClaim<string>>();
 		}
 
 		public override string ToString()
 		{
 			return Name;
 		}
+		public List<IdentityRoleClaim<string>> Claims { get; set; }
 	}
 }

--- a/AspNetCore.Identity.Mongo/Stores/RoleStore.cs
+++ b/AspNetCore.Identity.Mongo/Stores/RoleStore.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using AspNetCore.Identity.Mongo.Model;
@@ -9,16 +11,18 @@ using MongoDB.Driver;
 
 namespace AspNetCore.Identity.Mongo.Stores
 {
-	public class RoleStore<TRole> : IQueryableRoleStore<TRole> where TRole : MongoRole
-	{
-		private readonly IMongoCollection<TRole> _collection;
+    public class RoleStore<TRole> :
+       IRoleClaimStore<TRole>,
+       IQueryableRoleStore<TRole> where TRole : MongoRole
+    {
+        private readonly IMongoCollection<TRole> _collection;
 
-		public RoleStore(IMongoCollection<TRole> collection)
-		{
-			_collection = collection;
-		}
+        public RoleStore(IMongoCollection<TRole> collection)
+        {
+            _collection = collection;
+        }
 
-		IQueryable<TRole> IQueryableRoleStore<TRole>.Roles
+        IQueryable<TRole> IQueryableRoleStore<TRole>.Roles
         {
             get
             {
@@ -29,63 +33,134 @@ namespace AspNetCore.Identity.Mongo.Stores
         }
 
         public async Task<IdentityResult> CreateAsync(TRole role, CancellationToken cancellationToken)
-		{
-			var found = await _collection.FirstOrDefaultAsync(x => x.NormalizedName == role.NormalizedName);
-			if (found == null) await _collection.InsertOneAsync(role, new InsertOneOptions(), cancellationToken);
-			return IdentityResult.Success;
-		}
+        {
+            var found = await _collection.FirstOrDefaultAsync(x => x.NormalizedName == role.NormalizedName);
+            if (found == null) await _collection.InsertOneAsync(role, new InsertOneOptions(), cancellationToken);
+            return IdentityResult.Success;
+        }
 
-		public async Task<IdentityResult> UpdateAsync(TRole role, CancellationToken cancellationToken)
-		{
-			await _collection.ReplaceOneAsync(x=>x.Id == role.Id, role, cancellationToken: cancellationToken);
-			return IdentityResult.Success;
-		}
+        public async Task<IdentityResult> UpdateAsync(TRole role, CancellationToken cancellationToken)
+        {
+            await _collection.ReplaceOneAsync(x => x.Id == role.Id, role, cancellationToken: cancellationToken);
+            return IdentityResult.Success;
+        }
 
-		public async Task<IdentityResult> DeleteAsync(TRole role, CancellationToken cancellationToken)
-		{
+        public async Task<IdentityResult> DeleteAsync(TRole role, CancellationToken cancellationToken)
+        {
             await _collection.DeleteOneAsync(x => x.Id == role.Id, cancellationToken);
             return IdentityResult.Success;
-		}
+        }
 
-		public async Task<string> GetRoleIdAsync(TRole role, CancellationToken cancellationToken)
-		{
-			return await Task.FromResult(role.Id);
-		}
-        
-		public async Task<string> GetRoleNameAsync(TRole role, CancellationToken cancellationToken)
-		{
-			return (await _collection.FirstOrDefaultAsync(x => x.Id == role.Id))?.Name ?? role.Name;
-		}
+        public async Task<string> GetRoleIdAsync(TRole role, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult(role.Id);
+        }
+
+        public async Task<string> GetRoleNameAsync(TRole role, CancellationToken cancellationToken)
+        {
+            return (await _collection.FirstOrDefaultAsync(x => x.Id == role.Id))?.Name ?? role.Name;
+        }
 
         public async Task SetRoleNameAsync(TRole role, string roleName, CancellationToken cancellationToken)
-		{
-			role.Name = roleName;
-			await _collection.UpdateOneAsync(x=>x.Id == role.Id, Builders<TRole>.Update.Set(x=>x.Name, roleName), cancellationToken: cancellationToken);
-		}
+        {
+            role.Name = roleName;
+            await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Name, roleName), cancellationToken: cancellationToken);
+        }
 
-		public async Task<string> GetNormalizedRoleNameAsync(TRole role, CancellationToken cancellationToken)
-		{
-			return await Task.FromResult(role.NormalizedName);
-		}
+        public async Task<string> GetNormalizedRoleNameAsync(TRole role, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult(role.NormalizedName);
+        }
 
         public async Task SetNormalizedRoleNameAsync(TRole role, string normalizedName, CancellationToken cancellationToken)
-		{
-			role.NormalizedName = normalizedName;
+        {
+            role.NormalizedName = normalizedName;
             await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.NormalizedName, normalizedName), cancellationToken: cancellationToken);
         }
 
         public Task<TRole> FindByIdAsync(string roleId, CancellationToken cancellationToken)
-		{
+        {
             return _collection.FirstOrDefaultAsync(x => x.Id == roleId);
-		}
-
-        public Task<TRole> FindByNameAsync(string normalizedRoleName, CancellationToken cancellationToken)
-		{
-			return _collection.FirstOrDefaultAsync(x => x.NormalizedName == normalizedRoleName);
         }
 
-		void IDisposable.Dispose()
-		{
-		}
-	}
+        public Task<TRole> FindByNameAsync(string normalizedRoleName, CancellationToken cancellationToken)
+        {
+            return _collection.FirstOrDefaultAsync(x => x.NormalizedName == normalizedRoleName);
+        }
+
+        public async Task<IList<Claim>> GetClaimsAsync(TRole role, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var dbRole = await _collection.FirstOrDefaultAsync(x => x.Id == role.Id);
+            return dbRole.Claims.Select(e => new Claim(e.ClaimType, e.ClaimValue)).ToList();
+        }
+
+        public async Task AddClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var currentClaim = role.Claims
+                                   .FirstOrDefault(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value);
+
+            if (currentClaim == null)
+            {
+                var identityRoleClaim = new IdentityRoleClaim<string>()
+                {
+                    ClaimType = claim.Type,
+                    ClaimValue = claim.Value
+                };
+
+                role.Claims.Add(identityRoleClaim);
+                await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);
+            }
+        }
+
+        public async Task AddClaimsAsync(TRole role, IEnumerable<Claim> claims, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var claim in claims)
+            {
+                var currentClaim = role.Claims
+                                  .FirstOrDefault(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value);
+
+                if (currentClaim == null)
+                {
+                    var identityRoleClaim = new IdentityRoleClaim<string>()
+                    {
+                        ClaimType = claim.Type,
+                        ClaimValue = claim.Value
+                    };
+                    role.Claims.Add(identityRoleClaim);
+                }
+            }
+            await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);
+
+            //await Add(user, x => x.Claims, identityClaim);
+
+        }
+
+        public Task RemoveClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            role.Claims.RemoveAll(x => x.ClaimType == claim.Type);
+            return _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);
+        }
+
+        public Task RemoveClaimsAsync(TRole role, IEnumerable<Claim> claims, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var claim in claims)
+            {
+                role.Claims.RemoveAll(x => x.ClaimType == claim.Type);
+            }
+            return _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+    }
 }

--- a/TestSite/Controllers/UserController.cs
+++ b/TestSite/Controllers/UserController.cs
@@ -25,7 +25,14 @@ namespace SampleSite.Controllers
             _userUserCollection = userCollection;
         }
 
-        public ActionResult Index(string id) => View(_userManager.Users);
+        public async Task<ActionResult> Index(string id)
+        {
+            await _roleManager.CreateAsync(new MongoRole("Admin"));
+            var role = await _roleManager.FindByNameAsync("Admin");
+            await _roleManager.AddClaimAsync(role, new Claim("Permission", "ManageCourses"));
+            return View(_userManager.Users);
+        }
+
 
         public async Task<ActionResult> AddToRole(string roleName, string userName)
         {

--- a/TestSite/Policy/AuthorizationPolicyProvider.cs
+++ b/TestSite/Policy/AuthorizationPolicyProvider.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Policy
+{
+    public class AuthorizationPolicyProvider : DefaultAuthorizationPolicyProvider
+    {
+        private readonly AuthorizationOptions _options;
+        private readonly IConfiguration _configuration;
+        public AuthorizationPolicyProvider(IOptions<AuthorizationOptions> options, IConfiguration configuration) : base(options)
+        {
+            _options = options.Value;
+            _configuration = configuration;
+        }
+
+        public override async Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
+        {
+            var defaultPolicy = await base.GetDefaultPolicyAsync();
+            var policy = await base.GetPolicyAsync(policyName);
+
+            if (policy == null)
+            {
+                policy = new AuthorizationPolicyBuilder()
+                            .AddRequirements(new HasClaimRequirement(policyName))
+                            .Build();
+                _options.AddPolicy(policyName, policy);
+            }
+            return policy;
+        }
+    }
+}

--- a/TestSite/Policy/HasClaimHandler.cs
+++ b/TestSite/Policy/HasClaimHandler.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Policy
+{
+    public class HasClaimHandler : AuthorizationHandler<HasClaimRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, HasClaimRequirement requirement)
+        {
+            if (!context.User.HasClaim(c => c.Type == "Permission"))
+                return Task.CompletedTask;
+
+            var userClaims = context.User.Claims.Where(c => c.Type == "Permission").ToList();
+            if (userClaims.Any(c => c.Value == requirement.UserClaims))
+            {
+                context.Succeed(requirement);
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/TestSite/Policy/HasClaimRequirement.cs
+++ b/TestSite/Policy/HasClaimRequirement.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Policy
+{
+    public class HasClaimRequirement : IAuthorizationRequirement
+    {
+        public string UserClaims { get; set; }
+        public HasClaimRequirement(string userClaims)
+        {
+            UserClaims = userClaims?? throw new ArgumentNullException(nameof(userClaims));
+        }
+    }
+}

--- a/TestSite/Startup.cs
+++ b/TestSite/Startup.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Hosting;
 using SampleSite.Identity;
 using AspNetCore.Identity.Mongo;
 using SampleSite.Mailing;
+using Microsoft.AspNetCore.Authorization;
+using Policy;
 
 namespace TestSite
 {
@@ -37,6 +39,9 @@ namespace TestSite
                     mongo.ConnectionString = ConnectionString;
                 }
             );
+
+            services.AddSingleton<IAuthorizationPolicyProvider, AuthorizationPolicyProvider>();
+            services.AddSingleton<IAuthorizationHandler, HasClaimHandler>();
 
             services.AddSingleton<IEmailSender, EmailSender>();
             services.AddRazorPages();

--- a/TestSite/appsettings.json
+++ b/TestSite/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "mongodb://localhost/testDB"
+    "DefaultConnection": "mongodb://localhost/MongoIdentityTestDb"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Claim property is added in MongoRole Model to support claims for specific roles.

 Extend RoleStore by inheriting the store from to support RoleClaims  Methods

` IRoleClaimStore<TRole>`

dynamic Policy creation is added  in TestSite Under Policy folder which will help to create dynamic policy rather than registering each policy on application startup methods.

```
services.AddSingleton<IAuthorizationPolicyProvider, AuthorizationPolicyProvider>();
            services.AddSingleton<IAuthorizationHandler, HasClaimHandler>();
```