### PR TITLE
Fixes Claim support for Roles

### DIFF
--- a/AspNetCore.Identity.Mongo/Stores/RoleStore.cs
+++ b/AspNetCore.Identity.Mongo/Stores/RoleStore.cs
@@ -91,6 +91,12 @@ namespace AspNetCore.Identity.Mongo.Stores
         public async Task<IList<Claim>> GetClaimsAsync(TRole role, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (role == null)
+            {
+                throw new ArgumentNullException(nameof(role));
+            }
+
             var dbRole = await _collection.FirstOrDefaultAsync(x => x.Id == role.Id);
             return dbRole.Claims.Select(e => new Claim(e.ClaimType, e.ClaimValue)).ToList();
         }
@@ -98,6 +104,15 @@ namespace AspNetCore.Identity.Mongo.Stores
         public async Task AddClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (role == null)
+            {
+                throw new ArgumentNullException(nameof(role));
+            }
+            if (claim == null)
+            {
+                throw new ArgumentNullException(nameof(claim));
+            }
 
             var currentClaim = role.Claims
                                    .FirstOrDefault(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value);
@@ -115,47 +130,20 @@ namespace AspNetCore.Identity.Mongo.Stores
             }
         }
 
-        public async Task AddClaimsAsync(TRole role, IEnumerable<Claim> claims, CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            foreach (var claim in claims)
-            {
-                var currentClaim = role.Claims
-                                  .FirstOrDefault(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value);
-
-                if (currentClaim == null)
-                {
-                    var identityRoleClaim = new IdentityRoleClaim<string>()
-                    {
-                        ClaimType = claim.Type,
-                        ClaimValue = claim.Value
-                    };
-                    role.Claims.Add(identityRoleClaim);
-                }
-            }
-            await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);
-
-            //await Add(user, x => x.Claims, identityClaim);
-
-        }
-
         public Task RemoveClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            role.Claims.RemoveAll(x => x.ClaimType == claim.Type);
-            return _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);
-        }
-
-        public Task RemoveClaimsAsync(TRole role, IEnumerable<Claim> claims, CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            foreach (var claim in claims)
+            if (role == null)
             {
-                role.Claims.RemoveAll(x => x.ClaimType == claim.Type);
+                throw new ArgumentNullException(nameof(role));
             }
+            if (claim == null)
+            {
+                throw new ArgumentNullException(nameof(claim));
+            }
+
+            role.Claims.RemoveAll(x => x.ClaimType == claim.Type && x.ClaimValue == claim.Value);
             return _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);
         }
 


### PR DESCRIPTION
hi, i did some fixes according to pull request #39 
1. For all methods which implementing IRoleClaimStore<TRole> added validation for null check for `TRole role` and `Claim claim` params. They can cause unhandled NullReferenceException exceptions.
2. `RemoveClaimAsync` method required validation for value. Now it is removing claims based on type and value. So you can't delete some necessary claims with the same type.
3. Deleted `AddClaimsAsync` and `RemoveClaimsAsync` methods. They are extension methods and not originally implement any interface or required by `RoleStore<TRole>`. 

All changes was done based on original [RoleStore](https://github.com/dotnet/aspnetcore/blob/master/src/Identity/EntityFrameworkCore/src/RoleStore.cs)