### PR TITLE
Performance improvement: directly return IQueryable<TUser/TRole>

### DIFF
--- a/AspNetCore.Identity.Mongo/Mongo/MongoUtil.cs
+++ b/AspNetCore.Identity.Mongo/Mongo/MongoUtil.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Driver;
 
@@ -49,95 +50,129 @@ namespace AspNetCore.Identity.Mongo.Mongo
 
         public static void AscendingIndex<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, object>> field)
         {
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
             var def = Builders<TItem>.IndexKeys.Ascending(field);
+
             collection.Indexes.CreateOne(new CreateIndexModel<TItem>(def));
         }
 
         public static void DescendingIndex<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, object>> field)
         {
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
             var def = Builders<TItem>.IndexKeys.Descending(field);
+
             collection.Indexes.CreateOne(new CreateIndexModel<TItem>(def));
         }
 
         public static void FullTextIndex<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, object>> field)
         {
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
             var def = Builders<TItem>.IndexKeys.Text(field);
+
             collection.Indexes.CreateOne(new CreateIndexModel<TItem>(def));
         }
 
-        public static async Task<IEnumerable<TItem>> TakeAsync<TItem>(this IMongoCollection<TItem> collection, int count, int skip = 0)
+        public static async Task<IEnumerable<TItem>> TakeAsync<TItem>(this IMongoCollection<TItem> collection, int count, int skip = 0, CancellationToken cancellationToken = default)
         {
-            return await (await collection.FindAsync(x => true, new FindOptions<TItem, TItem>()
-            {
-                Skip = skip,
-                Limit = count
-            })).ToListAsync();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return await (await collection.FindAsync(x => true, new FindOptions<TItem, TItem>(){Skip = skip,Limit = count}, cancellationToken).ConfigureAwait(false)).ToListAsync().ConfigureAwait(false);
         }
 
-        public static async Task<List<TItem>> All<TItem>(this IMongoCollection<TItem> mongoCollection)
+        public static async Task<List<TItem>> AllAsync<TItem>(this IMongoCollection<TItem> collection, CancellationToken cancellationToken = default)
         {
-            return (await (await mongoCollection.FindAsync(Builders<TItem>.Filter.Empty)).ToListAsync());
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return await (await collection.FindAsync(Builders<TItem>.Filter.Empty, cancellationToken: cancellationToken).ConfigureAwait(false)).ToListAsync().ConfigureAwait(false);
         }
 
-        public static async Task<bool> AnyAsync<TItem>(this IMongoCollection<TItem> mongoCollection)
+        public static async Task<bool> AnyAsync<TItem>(this IMongoCollection<TItem> collection, CancellationToken cancellationToken = default)
         {
-            return await (await mongoCollection.FindAsync(x => true,LimitOneOption<TItem>())).AnyAsync();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return await (await collection.FindAsync(x => true, LimitOneOption<TItem>(), cancellationToken).ConfigureAwait(false)).AnyAsync().ConfigureAwait(false);
         }
 
-        public static async Task<bool> AnyAsync<TItem>(this IMongoCollection<TItem> mongoCollection, Expression<Func<TItem, bool>> p)
+        public static async Task<bool> AnyAsync<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, bool>> p, CancellationToken cancellationToken = default)
         {
-            return await (await mongoCollection.FindAsync(p, LimitOneOption<TItem>())).AnyAsync();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return await (await collection.FindAsync(p, LimitOneOption<TItem>(), cancellationToken).ConfigureAwait(false)).AnyAsync().ConfigureAwait(false);
         }
 
-        public static async Task<TItem> FirstOrDefault<TItem>(this IMongoCollection<TItem> mongoCollection)
+        public static async Task<TItem> FirstOrDefault<TItem>(this IMongoCollection<TItem> collection, CancellationToken cancellationToken = default)
         {
-            return await (await mongoCollection.FindAsync(Builders<TItem>.Filter.Empty,LimitOneOption<TItem>())).FirstOrDefaultAsync();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return await (await collection.FindAsync(Builders<TItem>.Filter.Empty, LimitOneOption<TItem>(), cancellationToken).ConfigureAwait(false)).FirstOrDefaultAsync().ConfigureAwait(false);
         }
 
-        public static TItem FirstOrDefault<TItem>(this IMongoCollection<TItem> mongoCollection, Expression<Func<TItem, bool>> p)
+        public static TItem FirstOrDefault<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, bool>> p)
         {
-            return (mongoCollection.Find(p)).FirstOrDefault();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return collection.Find(p).FirstOrDefault();
         }
 
-        public static async Task<TItem> FirstOrDefaultAsync<TItem>(this IMongoCollection<TItem> mongoCollection, FilterDefinition<TItem> p)
+        public static async Task<TItem> FirstOrDefaultAsync<TItem>(this IMongoCollection<TItem> collection, FilterDefinition<TItem> p, CancellationToken cancellationToken = default)
         {
-            return await (await mongoCollection.FindAsync(p,LimitOneOption<TItem>())).FirstOrDefaultAsync();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return await (await collection.FindAsync(p, LimitOneOption<TItem>(), cancellationToken).ConfigureAwait(false)).FirstOrDefaultAsync().ConfigureAwait(false);
         }
 
-        public static async Task<TItem> FirstOrDefaultAsync<TItem>(this IMongoCollection<TItem> mongoCollection, Expression<Func<TItem, bool>> p)
+        public static async Task<TItem> FirstOrDefaultAsync<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, bool>> p, CancellationToken cancellationToken = default)
         {
-            return await (await mongoCollection.FindAsync(p,LimitOneOption<TItem>())).FirstOrDefaultAsync();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return await (await collection.FindAsync(p, LimitOneOption<TItem>(), cancellationToken).ConfigureAwait(false)).FirstOrDefaultAsync().ConfigureAwait(false);
         }
 
-        public static async Task ForEachAsync<TItem>(this IMongoCollection<TItem> mongoCollection, Expression<Func<TItem, bool>> p,  Action<TItem> action)
+        public static async Task ForEachAsync<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, bool>> p, Action<TItem> action, CancellationToken cancellationToken = default)
         {
-            await (await mongoCollection.FindAsync(p)).ForEachAsync(action);
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            await (await collection.FindAsync(p, cancellationToken: cancellationToken).ConfigureAwait(false)).ForEachAsync(action).ConfigureAwait(false);
         }
 
-        public static async Task ForEachAsync<TItem>(this IMongoCollection<TItem> mongoCollection, Action<TItem> action)
+        public static async Task ForEachAsync<TItem>(this IMongoCollection<TItem> collection, Action<TItem> action, CancellationToken cancellationToken = default)
         {
-            await (await mongoCollection.FindAsync(Builders<TItem>.Filter.Empty)).ForEachAsync(action);
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            await (await collection.FindAsync(Builders<TItem>.Filter.Empty, cancellationToken: cancellationToken).ConfigureAwait(false)).ForEachAsync(action).ConfigureAwait(false);
         }
 
-        public static async Task<IEnumerable<TItem>> WhereAsync<TItem>(this IMongoCollection<TItem> mongoCollection, FilterDefinition<TItem> p)
+        public static async Task<IEnumerable<TItem>> WhereAsync<TItem>(this IMongoCollection<TItem> collection, FilterDefinition<TItem> p, CancellationToken cancellationToken = default)
         {
-            return (await mongoCollection.FindAsync(p)).ToEnumerable();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return (await collection.FindAsync(p).ConfigureAwait(false)).ToEnumerable();
         }
 
-        public static async Task<IEnumerable<TItem>> WhereAsync<TItem>(this IMongoCollection<TItem> mongoCollection, Expression<Func<TItem, bool>> p)
+        public static async Task<IEnumerable<TItem>> WhereAsync<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, bool>> p, CancellationToken cancellationToken = default)
         {
-            return (await mongoCollection.FindAsync(p)).ToEnumerable();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return (await collection.FindAsync(p, cancellationToken: cancellationToken).ConfigureAwait(false)).ToEnumerable();
         }
 
-        public static async Task<IEnumerable<TItem>> TextSearch<TItem>(this IMongoCollection<TItem> mongoCollection, string str)
+        public static async Task<IEnumerable<TItem>> TextSearch<TItem>(this IMongoCollection<TItem> collection, string str, CancellationToken cancellationToken = default)
         {
-            return (await mongoCollection.FindAsync(Builders<TItem>.Filter.Text(str))).ToEnumerable();
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            return (await collection.FindAsync(Builders<TItem>.Filter.Text(str), cancellationToken: cancellationToken).ConfigureAwait(false)).ToEnumerable();
         }
 
-        public static async Task<IEnumerable<TItem>> TextSearch<TItem>(this IMongoCollection<TItem> mongoCollection, string str, Expression<Func<TItem, bool>> filter)
+        public static async Task<IEnumerable<TItem>> TextSearch<TItem>(this IMongoCollection<TItem> collection, string str, Expression<Func<TItem, bool>> filter, CancellationToken cancellationToken = default)
         {
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
             var f = Builders<TItem>.Filter.Text(str) & filter;
-            return (await mongoCollection.FindAsync(f)).ToEnumerable();
+
+            return (await collection.FindAsync(f, cancellationToken: cancellationToken).ConfigureAwait(false)).ToEnumerable();
         }
     }
 }

--- a/AspNetCore.Identity.Mongo/MongoUtil.cs
+++ b/AspNetCore.Identity.Mongo/MongoUtil.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Driver;
 
@@ -24,13 +25,9 @@ namespace AspNetCore.Identity.Mongo
                 .GetCollection<TItem>(collectionName ?? type.Name.ToLowerInvariant());
         }
 
-        public static async Task<IEnumerable<TItem>> TakeAsync<TItem>(this IMongoCollection<TItem> collection, int count, int skip = 0)
+        public static async Task<IEnumerable<TItem>> TakeAsync<TItem>(this IMongoCollection<TItem> collection, int count, int skip = 0, CancellationToken cancellationToken = default)
         {
-            return await (await collection.FindAsync(x => true, new FindOptions<TItem, TItem>()
-            {
-                Skip = skip,
-                Limit = count
-            })).ToListAsync();
+            return await (await collection.FindAsync(x => true, new FindOptions<TItem, TItem>{ Skip = skip, Limit = count }, cancellationToken).ConfigureAwait(false)).ToListAsync().ConfigureAwait(false);
         }
 
         public static TItem FirstOrDefault<TItem>(this IMongoCollection<TItem> mongoCollection)
@@ -43,15 +40,15 @@ namespace AspNetCore.Identity.Mongo
             return mongoCollection.Find(p).FirstOrDefault();
         }
 
-        public static async Task<TItem> FirstOrDefaultAsync<TItem>(this IMongoCollection<TItem> mongoCollection, Expression<Func<TItem, bool>> p)
+        public static async Task<TItem> FirstOrDefaultAsync<TItem>(this IMongoCollection<TItem> mongoCollection, Expression<Func<TItem, bool>> p, CancellationToken cancellationToken)
         {
-            return await (await mongoCollection.FindAsync(p)).FirstOrDefaultAsync();
+            return await (await mongoCollection.FindAsync(p, cancellationToken: cancellationToken).ConfigureAwait(false)).FirstOrDefaultAsync().ConfigureAwait(false);
         }
 
 
-        public static async Task<IEnumerable<TItem>> WhereAsync<TItem>(this IMongoCollection<TItem> mongoCollection, Expression<Func<TItem, bool>> p)
+        public static async Task<IEnumerable<TItem>> WhereAsync<TItem>(this IMongoCollection<TItem> mongoCollection, Expression<Func<TItem, bool>> p, CancellationToken cancellationToken)
         {
-            return (await mongoCollection.FindAsync(p)).ToEnumerable();
+            return (await mongoCollection.FindAsync(p, cancellationToken: cancellationToken).ConfigureAwait(false)).ToEnumerable();
         }
     }
 }

--- a/AspNetCore.Identity.Mongo/Stores/RoleStore.cs
+++ b/AspNetCore.Identity.Mongo/Stores/RoleStore.cs
@@ -9,12 +9,15 @@ using AspNetCore.Identity.Mongo.Mongo;
 using Microsoft.AspNetCore.Identity;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace AspNetCore.Identity.Mongo.Stores
 {
     public class RoleStore<TRole> :
-       IRoleClaimStore<TRole>,
-       IQueryableRoleStore<TRole> where TRole : MongoRole
+        IRoleClaimStore<TRole>,
+        IQueryableRoleStore<TRole>
+        
+        where TRole : MongoRole
     {
         private readonly IMongoCollection<TRole> _collection;
 
@@ -23,15 +26,7 @@ namespace AspNetCore.Identity.Mongo.Stores
             _collection = collection;
         }
 
-        IQueryable<TRole> IQueryableRoleStore<TRole>.Roles
-        {
-            get
-            {
-                var task = _collection.All();
-                Task.WaitAny(task);
-                return task.Result.AsQueryable();
-            }
-        }
+        IQueryable<TRole> IQueryableRoleStore<TRole>.Roles => _collection.AsQueryable();
 
         public async Task<IdentityResult> CreateAsync(TRole role, CancellationToken cancellationToken)
         {

--- a/AspNetCore.Identity.Mongo/Stores/RoleStore.cs
+++ b/AspNetCore.Identity.Mongo/Stores/RoleStore.cs
@@ -26,92 +26,111 @@ namespace AspNetCore.Identity.Mongo.Stores
             _collection = collection;
         }
 
-        IQueryable<TRole> IQueryableRoleStore<TRole>.Roles => _collection.AsQueryable();
+        public IQueryable<TRole> Roles => _collection.AsQueryable();
 
         public async Task<IdentityResult> CreateAsync(TRole role, CancellationToken cancellationToken)
         {
-            var found = await _collection.FirstOrDefaultAsync(x => x.NormalizedName == role.NormalizedName);
-            if (found == null) await _collection.InsertOneAsync(role, new InsertOneOptions(), cancellationToken);
+            if (role == null) throw new ArgumentNullException(nameof(role));
+
+            var found = await _collection.FirstOrDefaultAsync(x => x.NormalizedName == role.NormalizedName, cancellationToken).ConfigureAwait(false);
+
+            if (found == null) await _collection.InsertOneAsync(role, cancellationToken: cancellationToken).ConfigureAwait(false);
+
             return IdentityResult.Success;
         }
 
         public async Task<IdentityResult> UpdateAsync(TRole role, CancellationToken cancellationToken)
         {
-            await _collection.ReplaceOneAsync(x => x.Id == role.Id, role, cancellationToken: cancellationToken);
+            if (role == null) throw new ArgumentNullException(nameof(role));
+
+            await _collection.ReplaceOneAsync(x => x.Id == role.Id, role, cancellationToken: cancellationToken).ConfigureAwait(false);
+
             return IdentityResult.Success;
         }
 
         public async Task<IdentityResult> DeleteAsync(TRole role, CancellationToken cancellationToken)
         {
-            await _collection.DeleteOneAsync(x => x.Id == role.Id, cancellationToken);
+            if (role == null) throw new ArgumentNullException(nameof(role));
+
+            await _collection.DeleteOneAsync(x => x.Id == role.Id, cancellationToken).ConfigureAwait(false);
+
             return IdentityResult.Success;
         }
 
-        public async Task<string> GetRoleIdAsync(TRole role, CancellationToken cancellationToken)
+        public Task<string> GetRoleIdAsync(TRole role, CancellationToken cancellationToken)
         {
-            return await Task.FromResult(role.Id.ToString());
+            if (role == null) throw new ArgumentNullException(nameof(role));
+
+            return Task.FromResult(role.Id.ToString());
         }
 
         public async Task<string> GetRoleNameAsync(TRole role, CancellationToken cancellationToken)
         {
-            return (await _collection.FirstOrDefaultAsync(x => x.Id == role.Id))?.Name ?? role.Name;
+            if (role == null) throw new ArgumentNullException(nameof(role));
+
+            return (await _collection.FirstOrDefaultAsync(x => x.Id == role.Id, cancellationToken: cancellationToken).ConfigureAwait(false))?.Name ?? role.Name;
         }
 
         public async Task SetRoleNameAsync(TRole role, string roleName, CancellationToken cancellationToken)
         {
+            if (role == null) throw new ArgumentNullException(nameof(role));
+            if (string.IsNullOrEmpty(roleName)) throw new ArgumentNullException(nameof(roleName));
+
             role.Name = roleName;
-            await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Name, roleName), cancellationToken: cancellationToken);
+
+            await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Name, roleName), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<string> GetNormalizedRoleNameAsync(TRole role, CancellationToken cancellationToken)
+        public Task<string> GetNormalizedRoleNameAsync(TRole role, CancellationToken cancellationToken)
         {
-            return await Task.FromResult(role.NormalizedName);
+            if (role == null) throw new ArgumentNullException(nameof(role));
+
+            return Task.FromResult(role.NormalizedName);
         }
 
-        public async Task SetNormalizedRoleNameAsync(TRole role, string normalizedName, CancellationToken cancellationToken)
+        public async Task SetNormalizedRoleNameAsync(TRole role, string normalizedRoleName, CancellationToken cancellationToken)
         {
-            role.NormalizedName = normalizedName;
-            await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.NormalizedName, normalizedName), cancellationToken: cancellationToken);
+            if (role == null) throw new ArgumentNullException(nameof(role));
+            if (string.IsNullOrEmpty(normalizedRoleName)) throw new ArgumentNullException(nameof(normalizedRoleName));
+
+            role.NormalizedName = normalizedRoleName;
+
+            await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.NormalizedName, normalizedRoleName), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         public Task<TRole> FindByIdAsync(string roleId, CancellationToken cancellationToken)
         {
-            return _collection.FirstOrDefaultAsync(x => x.Id == ObjectId.Parse(roleId));
+            if (string.IsNullOrEmpty(roleId)) throw new ArgumentNullException(nameof(roleId));
+
+            return _collection.FirstOrDefaultAsync(x => x.Id == ObjectId.Parse(roleId), cancellationToken: cancellationToken);
         }
 
         public Task<TRole> FindByNameAsync(string normalizedRoleName, CancellationToken cancellationToken)
         {
-            return _collection.FirstOrDefaultAsync(x => x.NormalizedName == normalizedRoleName);
+            if (string.IsNullOrEmpty(normalizedRoleName)) throw new ArgumentNullException(nameof(normalizedRoleName));
+
+            return _collection.FirstOrDefaultAsync(x => x.NormalizedName == normalizedRoleName, cancellationToken: cancellationToken);
         }
 
         public async Task<IList<Claim>> GetClaimsAsync(TRole role, CancellationToken cancellationToken = default)
         {
+            if (role == null) throw new ArgumentNullException(nameof(role));
+
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (role == null)
-            {
-                throw new ArgumentNullException(nameof(role));
-            }
+            var dbRole = await _collection.FirstOrDefaultAsync(x => x.Id == role.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            var dbRole = await _collection.FirstOrDefaultAsync(x => x.Id == role.Id);
             return dbRole.Claims.Select(e => new Claim(e.ClaimType, e.ClaimValue)).ToList();
         }
 
         public async Task AddClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
         {
+            if (role == null) throw new ArgumentNullException(nameof(role));
+            if (claim == null) throw new ArgumentNullException(nameof(claim));
+
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (role == null)
-            {
-                throw new ArgumentNullException(nameof(role));
-            }
-            if (claim == null)
-            {
-                throw new ArgumentNullException(nameof(claim));
-            }
-
-            var currentClaim = role.Claims
-                                   .FirstOrDefault(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value);
+            var currentClaim = role.Claims.FirstOrDefault(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value);
 
             if (currentClaim == null)
             {
@@ -122,29 +141,31 @@ namespace AspNetCore.Identity.Mongo.Stores
                 };
 
                 role.Claims.Add(identityRoleClaim);
-                await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);
+
+                await _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
 
         public Task RemoveClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
         {
+            if (role == null) throw new ArgumentNullException(nameof(role));
+            if (claim == null) throw new ArgumentNullException(nameof(claim));
+
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (role == null)
-            {
-                throw new ArgumentNullException(nameof(role));
-            }
-            if (claim == null)
-            {
-                throw new ArgumentNullException(nameof(claim));
-            }
-
             role.Claims.RemoveAll(x => x.ClaimType == claim.Type && x.ClaimValue == claim.Value);
+
             return _collection.UpdateOneAsync(x => x.Id == role.Id, Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);
         }
 
-        void IDisposable.Dispose()
+        protected virtual void Dispose(bool disposing)
         {
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/AspNetCore.Identity.Mongo/Stores/UserStore.cs
+++ b/AspNetCore.Identity.Mongo/Stores/UserStore.cs
@@ -10,6 +10,7 @@ using AspNetCore.Identity.Mongo.Mongo;
 using Microsoft.AspNetCore.Identity;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace AspNetCore.Identity.Mongo.Stores
 {
@@ -51,15 +52,7 @@ namespace AspNetCore.Identity.Mongo.Stores
             _normalizer = normalizer;
         }
 
-        public IQueryable<TUser> Users
-        {
-            get
-            {
-                var task = _userCollection.All();
-                Task.WaitAny(task);
-                return task.Result.AsQueryable();
-            }
-        }
+        public IQueryable<TUser> Users => _userCollection.AsQueryable();
 
         private async Task Update<TFIELD>(TUser user, Expression<Func<TUser, TFIELD>> expression, TFIELD value)
         {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Microsoft.AspNetCore.Identity.Mongo
+# AspNetCore.Identity.Mongo
 
-This is a MongoDB provider for the ASP.NET Core 2 Identity framework. It is completely written from scratch and provides support for all Identity framework interfaces:
+This is a MongoDB provider for the ASP.NET Core Identity framework. It is completely written from scratch and provides support for all Identity framework interfaces:
 
 * UserClaimStore
 * IUserLoginStore
@@ -17,7 +17,10 @@ This is a MongoDB provider for the ASP.NET Core 2 Identity framework. It is comp
 * IRoleStore
 * IQueryableRoleStore
 
-## Dot Net Core 2.2 and 3.0 
+## Dot Net Core 2.2 and 3.0
+
+[![NuGet](https://img.shields.io/nuget/v/AspNetCore.Identity.Mongo.svg)](https://www.nuget.org/packages/AspNetCore.Identity.Mongo/)
+
 For 2.2 use Nuget packages of the 5 series ( latest 5.3 )
 
 For 3.0 use Nuget packages of the 6 series ( latest 6.3 )


### PR DESCRIPTION
Performance improvement: directly return IQueryable<TUser> and IQueryable<TRole> from the respective method thus avoiding the need to download all the entities each time.