### PR TITLE
added instruction how migrate from version 3.1.5 to 6.7.0

### DIFF
--- a/AspNetCore.Identity.Mongo.sln
+++ b/AspNetCore.Identity.Mongo.sln
@@ -18,10 +18,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{0B883132-A85E-4EA6-9ADC-1EFD7E006F3E}"
 	ProjectSection(SolutionItems) = preProject
+		docs\MigrationGuideFromVersion3_1_5ToVersion6_7_0AndUpper.md = docs\MigrationGuideFromVersion3_1_5ToVersion6_7_0AndUpper.md
 		docs\MigrationGuideToVersion6_7_0AndUpper.md = docs\MigrationGuideToVersion6_7_0AndUpper.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbMigrator", "DbMigrator\DbMigrator.csproj", "{82CBD4AB-54F5-4438-8B26-6D3BC5B33B19}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbMigrator", "DbMigrator\DbMigrator.csproj", "{82CBD4AB-54F5-4438-8B26-6D3BC5B33B19}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ services.AddIdentityMongoDbProvider<ApplicationUser, ApplicationRole>(identityOp
 
 ## Migration guide to version 6.7.0+
 Started from version 6.7.0 library has new functionality and improvements which can broke you current projects.<br>
-[There](./docs/MigrationGuideToVersion6_7_0AndUpper.md) you can find information how to migrate to newest version.
+[There](./docs/MigrationGuideToVersion6_7_0AndUpper.md) you can find information how to migrate from 6.0.0-6.3.5 to newest version.
+[There](./docs/MigrationGuideFromVersion3_1_5ToVersion6_7_0AndUpper.md) you can find information how to migrate from 3.1.5 to newest version.
+
+If you has different version of library and want to update it, just create new issue. We will try to help you or will create new instruction.
 
 ## License
 This project is licensed under the [MIT license](./blob/master/LICENSE.txt)

--- a/docs/MigrationGuideFromVersion3_1_5ToVersion6_7_0AndUpper.md
+++ b/docs/MigrationGuideFromVersion3_1_5ToVersion6_7_0AndUpper.md
@@ -1,0 +1,43 @@
+## Migration guide from version 3.1.5 to version 6.7.0+
+Differences between versions:
+* `MongoUser.Roles` property contains id of role instead of NormalizedName
+* `MongoUser.Claims` has new structure of `Claim` object
+* `MongoRole` has 2 new properties `Claims` and `ConcurrencyStamp`.
+
+Lower you can find simple scripts to do necessary updates.<br>
+**NOTE!:** Before do anything please **[dump](https://docs.mongodb.com/manual/reference/program/mongodump/index.html)** your data.
+
+1. Users collections:
+```
+db.Users.updateMany( {}, { $rename: { "LockoutEndDateUtc": "LockoutEnd" } } )
+db.Users.find({}).
+    forEach(function(item){
+        // claims processing
+        var newClaimsArray = [];
+        item.Claims.forEach(function(claim){
+           newClaimsArray.push({
+                "_id" : 0,
+                "UserId" : null,
+                "ClaimType" : claim.Type,
+                "ClaimValue" : claim.Value
+            }); 
+        });
+        item.Claims = newClaimsArray;
+        
+        // roles processing
+        var newRolesArray = [];
+        item.Roles.forEach(function(role){
+           var originalRole = db.Roles.findOne({NormalizedName : role});
+           newRolesArray.push(originalRole._id.str); 
+        });
+        item.Roles = newRolesArray;
+        
+        db.Users.save(item);
+        }
+    )
+```
+
+2. Roles collcetions:
+```
+db.Roles.updateMany({}, {$set : {Claims : [], ConcurrencyStamp : ""}})
+```

--- a/docs/MigrationGuideToVersion6_7_0AndUpper.md
+++ b/docs/MigrationGuideToVersion6_7_0AndUpper.md
@@ -1,4 +1,4 @@
-## Migration guide to version 6.7.0+
+## Migration guide from version 6.0.0-6.3.5 to version 6.7.0+
 Started from version 6.7.0 library has 2 big changes:
 * `MongoRole` and `MongoUser` use native MongoBD ObjectId type instead of string.
 * `MongoRole` has new property `Claims`.
@@ -7,9 +7,8 @@ According to changes you need to do 2 updates:
 1. update **"_id"** from **"5e88749c85924566b02855cd"** to **ObjectId("5e88749c85924566b02855cd")** in Users and Roles collections
 2. add empty array to Roles collection
 
-Lower you can find simple scripts to do this updated.<br>
+Lower you can find simple scripts to do this updates.<br>
 **NOTE!:** Before do anything please **[dump](https://docs.mongodb.com/manual/reference/program/mongodump/index.html)** your data.
-
 
 1. 
 ```
@@ -25,6 +24,7 @@ db.Users.find({_id : {$type : 2}}). //find all _id prop with type string
 ```
 Then run this script for Roles collection. Simple change Users => Roles (3 places)<br>
 [MongoDB types](https://docs.mongodb.com/manual/reference/operator/query/type/)
+
 2. 
 ```
 db.Roles.updateMany({}, {$set : {Claims : []}})


### PR DESCRIPTION
I've created new instruction how migrate from version 3.1.5 to 6.7.0. According to issue #61 