### PR TITLE
Fix adding claims to role when used parameterless role constructor

### DIFF
--- a/AspNetCore.Identity.Mongo/Model/MongoRole.cs
+++ b/AspNetCore.Identity.Mongo/Model/MongoRole.cs
@@ -9,13 +9,13 @@ namespace AspNetCore.Identity.Mongo.Model
     {
         public MongoRole()
         {
+            Claims = new List<IdentityRoleClaim<string>>();
         }
 
-        public MongoRole(string name)
+        public MongoRole(string name) : this()
         {
             Name = name;
             NormalizedName = name.ToUpperInvariant();
-            Claims = new List<IdentityRoleClaim<string>>();
         }
 
         public override string ToString()


### PR DESCRIPTION
When you try to create a new role using the default parameterless constructor, you must explicitly set Claims property to a new List, otherwise you get a null reference exception from this line https://github.com/matteofabbri/AspNetCore.Identity.Mongo/blob/95920fa646f67ac40aef0db032d0bb5bac0b5ec2/AspNetCore.Identity.Mongo/Stores/RoleStore.cs#L133. This pull request should solve it.