### PR TITLE
added ObjectIdConverter

### DIFF
--- a/AspNetCore.Identity.Mongo/Mongo/ObjectIdConverter.cs
+++ b/AspNetCore.Identity.Mongo/Mongo/ObjectIdConverter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+
+namespace AspNetCore.Identity.Mongo.Mongo
+{
+    class ObjectIdConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value is string)
+            {
+                return MongoDB.Bson.ObjectId.Parse((string)value);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return true;
+            }
+
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return ((MongoDB.Bson.ObjectId)value).ToString();
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/AspNetCore.Identity.Mongo/MongoIdentityExtensions.cs
+++ b/AspNetCore.Identity.Mongo/MongoIdentityExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using AspNetCore.Identity.Mongo.Migrations;
 using AspNetCore.Identity.Mongo.Model;
@@ -88,11 +89,25 @@ namespace AspNetCore.Identity.Mongo
             services.AddSingleton(x => userCollection);
             services.AddSingleton(x => roleCollection);
 
+            // register custom ObjectId TypeConverter
+            if (typeof(TKey) == typeof(ObjectId))
+            {
+                RegisterTypeConverter<ObjectId, ObjectIdConverter>();
+            }
+
             // Identity Services
             services.AddTransient<IRoleStore<TRole>>(x => new RoleStore<TRole, TKey>(roleCollection));
             services.AddTransient<IUserStore<TUser>>(x => new UserStore<TUser, TRole, TKey>(userCollection, new RoleStore<TRole, TKey>(roleCollection), x.GetService<ILookupNormalizer>()));
 
             return builder;
+        }
+
+        private static void RegisterTypeConverter<T, TC>() where TC : TypeConverter
+        {
+            Attribute[] attr = new Attribute[1];
+            TypeConverterAttribute vConv = new TypeConverterAttribute(typeof(TC));
+            attr[0] = vConv;
+            TypeDescriptor.AddAttributes(typeof(T), attr);
         }
     }
 }


### PR DESCRIPTION
fix for #74 

Mongodb does not provide default TypeConverter for type `MongoDB.Bson.ObjectId`.
So i added `ObjectIdConverter` which registered if type of `Tkey` equals `MongoDB.Bson.ObjectId`.

Also it won't be implemented (at least in near future).
[[CSHARP-835]](https://jira.mongodb.org/browse/CSHARP-835)
[[CSHARP-2469]](https://jira.mongodb.org/browse/CSHARP-2469)