### PR TITLE
Solution to NET 5 and nuget updates to latest

### DIFF
--- a/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
+++ b/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
@@ -34,9 +34,9 @@ Thanks to GitHub users: vova3211, artem-kovalev, DNemtsov, haseeb200, mattwelke,
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.1.7" />
-    <PackageReference Include="MongoDB.Driver" Version="2.11.1" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.11.5" />
   </ItemGroup>
 
 </Project>

--- a/SelfCheck/SelfCheck.csproj
+++ b/SelfCheck/SelfCheck.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>aspnet-Sito4-ECDA30E4-4450-4860-B34F-51BF996C8621</UserSecretsId>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>SampleSite</RootNamespace>
@@ -11,10 +11,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.29" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="MongoDB.Driver" Version="2.11.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.11.5" />
   </ItemGroup>
 
 

--- a/TestSite/TestSite.csproj
+++ b/TestSite/TestSite.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>aspnet-TestSite-4862F257-7F38-4DD8-A1E1-A4E86B434B28</UserSecretsId>
     <DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>
   </PropertyGroup>
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.1" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Solution to NET 5 and nuget Identity update to 5.0.1 mongodb to 2.11.5 and htmlagilitypack to 1.11.29

Before you add this.
Create branch 3.1 to support Net core 3 version.
And the master will be Net 5 support
