### PR TITLE
AddMongoDbStores extension to register only stores.

### DIFF
--- a/src/AspNetCore.Identity.Mongo/Mongo/TypeConverterResolver.cs
+++ b/src/AspNetCore.Identity.Mongo/Mongo/TypeConverterResolver.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace AspNetCore.Identity.Mongo.Mongo
+{
+    internal static class TypeConverterResolver
+    {
+        internal static void RegisterTypeConverter<T, TC>() where TC : TypeConverter
+        {
+            Attribute[] attr = new Attribute[1];
+            TypeConverterAttribute vConv = new TypeConverterAttribute(typeof(TC));
+            attr[0] = vConv;
+            TypeDescriptor.AddAttributes(typeof(T), attr);
+        }
+    }
+}

--- a/src/AspNetCore.Identity.Mongo/MongoIdentityExtensions.cs
+++ b/src/AspNetCore.Identity.Mongo/MongoIdentityExtensions.cs
@@ -100,7 +100,7 @@ namespace AspNetCore.Identity.Mongo
             // register custom ObjectId TypeConverter
             if (typeof(TKey) == typeof(ObjectId))
             {
-                RegisterTypeConverter<ObjectId, ObjectIdConverter>();
+                TypeConverterResolver.RegisterTypeConverter<ObjectId, ObjectIdConverter>();
             }
 
             // Identity Services
@@ -108,14 +108,6 @@ namespace AspNetCore.Identity.Mongo
             services.AddTransient<IUserStore<TUser>>(x => new UserStore<TUser, TRole, TKey>(userCollection, new RoleStore<TRole, TKey>(roleCollection), x.GetService<ILookupNormalizer>()));
 
             return builder;
-        }
-
-        private static void RegisterTypeConverter<T, TC>() where TC : TypeConverter
-        {
-            Attribute[] attr = new Attribute[1];
-            TypeConverterAttribute vConv = new TypeConverterAttribute(typeof(TC));
-            attr[0] = vConv;
-            TypeDescriptor.AddAttributes(typeof(T), attr);
         }
     }
 }

--- a/src/AspNetCore.Identity.Mongo/MongoStoreExtensions.cs
+++ b/src/AspNetCore.Identity.Mongo/MongoStoreExtensions.cs
@@ -1,0 +1,55 @@
+﻿using AspNetCore.Identity.Mongo.Migrations;
+using AspNetCore.Identity.Mongo.Model;
+using AspNetCore.Identity.Mongo.Mongo;
+using AspNetCore.Identity.Mongo.Stores;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AspNetCore.Identity.Mongo
+{
+    public static class MongoStoreExtensions
+    {
+        public static IdentityBuilder AddMongoDbStores<TUser>(this IdentityBuilder builder, Action<MongoIdentityOptions> setupDatabaseAction)
+            where TUser : MongoUser
+        {
+            return AddMongoDbStores<TUser, MongoRole, ObjectId>(builder, setupDatabaseAction);
+        }
+
+        public static IdentityBuilder AddMongoDbStores<TUser, TRole, TKey>(this IdentityBuilder builder, Action<MongoIdentityOptions> setupDatabaseAction)
+            where TKey : IEquatable<TKey>
+            where TUser : MongoUser<TKey>
+            where TRole : MongoRole<TKey>
+        {
+            var dbOptions = new MongoIdentityOptions();
+            setupDatabaseAction(dbOptions);
+
+            var migrationCollection = MongoUtil.FromConnectionString<MigrationHistory>(dbOptions, dbOptions.MigrationCollection);
+
+            Task.WaitAny(Migrator.Apply(migrationCollection));
+
+            var userCollection = MongoUtil.FromConnectionString<TUser>(dbOptions, dbOptions.UsersCollection);
+            var roleCollection = MongoUtil.FromConnectionString<TRole>(dbOptions, dbOptions.RolesCollection);
+
+            builder.Services.AddSingleton(x => userCollection);
+            builder.Services.AddSingleton(x => roleCollection);
+
+            // register custom ObjectId TypeConverter
+            if (typeof(TKey) == typeof(ObjectId))
+            {
+                TypeConverterResolver.RegisterTypeConverter<ObjectId, ObjectIdConverter>();
+            }
+
+            // Identity Services
+            builder.Services.AddTransient<IRoleStore<TRole>>(x => new RoleStore<TRole, TKey>(roleCollection));
+            builder.Services.AddTransient<IUserStore<TUser>>(x => new UserStore<TUser, TRole, TKey>(userCollection, new RoleStore<TRole, TKey>(roleCollection), x.GetService<ILookupNormalizer>()));
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: [CONTRIBUTING](https://github.com/matteofabbri/AspNetCore.Identity.Mongo/blob/master/CONTRIBUTING.md) -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Extension that allows user register only mongodb store and other Identity stuff by yourself

Does this close any currently open issues?
------------------------------------------
Closes #99 


Any relevant logs, error output, etc?
-------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Win10

**.Net Core Verion:** .Net 5.0

Does this introduce a breaking change?
-----------------------------------------
<!--  (check one with "x") -->
- [ ] Yes
- [x] No

Any other comments?
-------------------
Example of usage:
```
services
	.AddIdentity<MongoUser, MongoRole>()
	.AddMongoDbStores<MongoUser, MongoRole, ObjectId>(mongo =>
	{
		mongo.ConnectionString = ConnectionString;
	})
	.AddSignInManager()
	.AddDefaultTokenProviders();
```
