### PR TITLE
Added .NET Core 3.1 and .NET 5 target frameworks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,18 @@
-﻿[*.cs]
+﻿[*]
+end_of_line = crlf
+trim_trailing_whitespace = true
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+charset = utf-8-bom
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+indent_style = space
+
+[*.cs]
 
 # IDE0058: Expression value is never used
 csharp_style_unused_value_expression_statement_preference = discard_variable:none

--- a/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
+++ b/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
@@ -37,10 +37,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.1'">
-		<PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="5.0.7" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.2" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.1.6" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="2.1.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
+++ b/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
@@ -1,44 +1,53 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <ApplicationIcon />
-    <StartupObject />
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>Mongo based identity framework for Asp.Net Core</Description>
-    <Copyright>Matteo Fabbri 2018</Copyright>
-    <RepositoryUrl>https://github.com/matteofabbri/AspNetCore.Identity.Mongo</RepositoryUrl>
-    <PackageTags>asp core identity mongo framework aspnetcore mongodb dotnetcore netcore</PackageTags>
-    <PackageId>AspNetCore.Identity.Mongo</PackageId>
-    <Authors>Matteo Fabbri</Authors>
-    <Company />
-    <Product>AspNetCore.Identity.Mongo</Product>
-    <Version>8.2.0</Version>
-    <AssemblyVersion>8.2.0.0</AssemblyVersion>
-    <FileVersion>8.2.0.0</FileVersion>
-    <PackageProjectUrl>https://github.com/matteofabbri/AspNetCore.Identity.Mongo</PackageProjectUrl>
-    <NeutralLanguage />
-    <PackageReleaseNotes>improved performance;
-added extension that allows register only mongodb stores.</PackageReleaseNotes>
-    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+		<ApplicationIcon />
+		<StartupObject />
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Description>Mongo based identity framework for Asp.Net Core</Description>
+		<Copyright>Matteo Fabbri 2018</Copyright>
+		<RepositoryUrl>https://github.com/matteofabbri/AspNetCore.Identity.Mongo</RepositoryUrl>
+		<PackageTags>asp core identity mongo framework aspnetcore mongodb dotnetcore netcore</PackageTags>
+		<PackageId>AspNetCore.Identity.Mongo</PackageId>
+		<Authors>Matteo Fabbri</Authors>
+		<Company />
+		<Product>AspNetCore.Identity.Mongo</Product>
+		<Version>8.2.0</Version>
+		<AssemblyVersion>8.2.0.0</AssemblyVersion>
+		<FileVersion>8.2.0.0</FileVersion>
+		<PackageProjectUrl>https://github.com/matteofabbri/AspNetCore.Identity.Mongo</PackageProjectUrl>
+		<NeutralLanguage />
+		<PackageReleaseNotes>
+			improved performance;
+			added extension that allows register only mongodb stores.
+		</PackageReleaseNotes>
+		<RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+		<RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="5.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.7" />
-    <PackageReference Include="MongoDB.Driver" Version="2.11.6" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="MongoDB.Driver" Version="2.11.6" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\LICENSE.txt">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup Condition="$(TargetFramework) != 'netstandard2.1'">
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.1'">
+		<PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="5.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.7" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\..\LICENSE.txt">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Project now targets .NET Core 3.1 and .NET 5 as an addition to .NET Standard 2.1

There's a vulnerability in `System.Text.Encodings.Web@4.5.0` introduced through `Microsoft.AspNetCore.Authentication@2.2.0` which is a reference used in `.NET Standard 2.1`. More info [here](https://github.com/dotnet/runtime/issues/49377).

This vulnerability throws a red flag when using automated vulnerability detection tools.

So targeting those frameworks fixes the issue and is a good way to provide existing functionality while moving forward.

Where has this been tested?
---------------------------
**Operating System:** Windows, Linux and macOS.

**.Net Core Version:** .NET 5 and .NET Core 3.1

Does this introduce a breaking change?
-----------------------------------------

- [ ] Yes
- [x] No