### PR TITLE
add dotnet 6 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is a MongoDB provider for the ASP.NET Core Identity framework. It is comple
 
 ## Dot Net Core Versions support
 
-Library supports **.Net 5.0**, **.Net Core 3.1**, **.Net Core 2.1**
+Library supports **.Net 6.0**, **.Net 5.0**, **.Net Core 3.1**, **.Net Core 2.1**
 simultaneously started from 8.3.0 nuget package.
 
 ## How to use:

--- a/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
+++ b/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
-		<TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 		<ApplicationIcon />
 		<StartupObject />
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
+++ b/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
@@ -26,7 +26,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MongoDB.Driver" Version="2.13.2" />
+		<PackageReference Include="MongoDB.Driver" Version="2.14.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework) != 'netstandard2.1'">
@@ -34,10 +34,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.1'">
-		<PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.2" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.1.6" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="2.1.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: [CONTRIBUTING](https://github.com/matteofabbri/AspNetCore.Identity.Mongo/blob/master/CONTRIBUTING.md) -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds support for targeting net6.0 and updates dependencies

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Windows 11

**.Net Core Verion:** net6.0

Does this introduce a breaking change?
-----------------------------------------
<!--  (check one with "x") -->
- [ ] Yes
- [x] No

Any other comments?
-------------------
Not 100% sure about updating `Microsoft.Extensions.Identity.Core` & `Microsoft.Extensions.Identity.Stores` from v2->v6 but prefer to use latest if not a breaking change. I've tested creating new user and login/logoff with sample application I'm working on. I can downgrade those if there's concerns.
