### PR TITLE
Fixed Optimistic Concurrency in UserStore

### DIFF
--- a/src/AspNetCore.Identity.Mongo/Stores/UserStore.cs
+++ b/src/AspNetCore.Identity.Mongo/Stores/UserStore.cs
@@ -210,7 +210,7 @@ namespace AspNetCore.Identity.Mongo.Stores
             if (user == null) throw new ArgumentNullException(nameof(user));
 
             var result = await _userCollection.DeleteOneAsync(x => x.Id.Equals(user.Id) && x.ConcurrencyStamp.Equals(user.ConcurrencyStamp), cancellationToken).ConfigureAwait(false);
-            if (!result.IsAcknowledged && result.DeletedCount == 0)
+            if (!result.IsAcknowledged || result.DeletedCount == 0)
             {
                 return IdentityResult.Failed(ErrorDescriber.ConcurrencyFailure());
             }
@@ -268,7 +268,7 @@ namespace AspNetCore.Identity.Mongo.Stores
 
             var result = await _userCollection.ReplaceOneAsync(x => x.Id.Equals(user.Id) && x.ConcurrencyStamp.Equals(currentConcurrencyStamp), user, ReplaceOptions, cancellationToken).ConfigureAwait(false);
 
-            if (!result.IsAcknowledged && result.ModifiedCount == 0)
+            if (!result.IsAcknowledged || result.ModifiedCount == 0)
             {
                 return IdentityResult.Failed(ErrorDescriber.ConcurrencyFailure());
             }


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------

The Concurrency Stamp checking is currently not working.
A update or delete count of 0 does indicate that the optimistic concurrency failed.


Where has this been tested?
---------------------------
**Operating System:**: MacOs 12.2

**.Net Core Version:**: 6.0.100

Does this introduce a breaking change?
-----------------------------------------
<!--  (check one with "x") -->
- [ ] Yes
- [X] No

Any other comments?
-------------------
…
