### PR TITLE
135 drop net 6 and add net 9 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
+          9.0.x
     - name: Restore dependencies
       run: dotnet restore ./src/AspNetCore.Identity.Mongo/
     - name: Build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,20 +24,21 @@ that is not occurring.
 
 #### **Dotnet version**
 
-* master branch refers only relevant and supported by Microsoft versions of dotnet. (Net 6.0 & Net 8.0 for now)
+* master branch refers only relevant and supported by Microsoft versions of dotnet.
 
 * older versions will be branched out, so if you want to make changes make sure you selected right branch.
 
 * relations table:
 
-| Dotnet Version | Branch                  |
-|----------------|-------------------------|
-| netstandard2.1 | `releases/8.x`          |
-| netcoreapp3.1  | `releases/8.x`          |
-| net5.0         | `releases/8.x`          |
-| net6.0         | `releases/8.x` `master` |
-| net7.0         |                         |
-| net8.0         | `master`                |
+| Dotnet Version | Branch         |
+|----------------|----------------|
+| netstandard2.1 | `releases/8.x` |
+| netcoreapp3.1  | `releases/8.x` |
+| net5.0         | `releases/8.x` |
+| net6.0         | `releases/9.x` |
+| net7.0         |                |
+| net8.0         | `master`       |
+| net9.0         | `master`       |
 
 #### **Issue and Pull request templates**
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ This is a MongoDB provider for the ASP.NET Core Identity framework. It is comple
 
 ## Dotnet Versions support
 
-Starting from `v9.0.0` library only supports **.Net 6.0** and **.Net 8.0** as they are
-only versions maintainable by Microsoft at the moment. [Supported Dotnet Versions](https://dotnet.microsoft.com/en-us/download/dotnet)
+The latest package version supports only dotnet versions maintainable by Microsoft at the moment [Supported Dotnet Versions](https://dotnet.microsoft.com/en-us/download/dotnet)
 
-Library supports **.Net 6.0**, **.Net 5.0**, **.Net Core 3.1**, **.Net Core 2.1**
-simultaneously started from 8.3.0 nuget package.
+Please refer to [this table](./CONTRIBUTING.md#dotnet-version) if you'd like to use this library with older dotnet versions.
 
 ## MongoDB Indexes
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Mongo2Go" Version="4.0.0" />
-        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit" Version="4.3.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">
           <PrivateAssets>all</PrivateAssets>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Mongo2Go" Version="4.0.0" />
-        <PackageReference Include="NUnit" Version="4.3.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Mongo2Go" Version="4.1.0" />
+        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/samples/TestSite/TestSite.csproj
+++ b/samples/TestSite/TestSite.csproj
@@ -8,7 +8,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.2" />
   </ItemGroup>
 
 

--- a/samples/TestSite/TestSite.csproj
+++ b/samples/TestSite/TestSite.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>aspnet-TestSite-4862F257-7F38-4DD8-A1E1-A4E86B434B28</UserSecretsId>
     <DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>
   </PropertyGroup>
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.0" />
   </ItemGroup>
 
 

--- a/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
+++ b/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ApplicationIcon />
         <StartupObject />
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -33,14 +33,14 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
-    <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.36" />
-        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.36" />
-    </ItemGroup>
-
     <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
         <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.11" />
         <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.11" />
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
+++ b/src/AspNetCore.Identity.Mongo/AspNetCore.Identity.Mongo.csproj
@@ -34,13 +34,13 @@
     </ItemGroup>
 
     <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.11" />
-        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.13" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.13" />
     </ItemGroup>
 
     <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: [CONTRIBUTING](https://github.com/matteofabbri/AspNetCore.Identity.Mongo/blob/master/CONTRIBUTING.md) -->

What does this implement/fix? Explain your changes.
---------------------------------------------------

- net9 support;
- omit old versions (net6)

Does this close any currently open issues?
------------------------------------------

#135 

Any relevant logs, error output, etc?
-------------------------------------
None

Where has this been tested?
---------------------------
**Operating System:** Windows 11

**.Net Core Verion:** Net8.0, NET9.0

Does this introduce a breaking change?
-----------------------------------------
<!--  (check one with "x") -->
- [ ] Yes
- [x] No

Any other comments?
-------------------
